### PR TITLE
Feature extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ dmypy.json
 .vscode/
 
 # Do not save data files
-.data/
+data/
+!src/deepdiva/data/

--- a/src/deepdiva/__init__.py
+++ b/src/deepdiva/__init__.py
@@ -6,3 +6,4 @@ Deepdiva imports
 
 import deepdiva.utils
 import deepdiva.data
+import deepdiva.features

--- a/src/deepdiva/features/__init__.py
+++ b/src/deepdiva/features/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Init for features
+"""

--- a/src/deepdiva/features/feature_extractor.py
+++ b/src/deepdiva/features/feature_extractor.py
@@ -67,7 +67,7 @@ class FeatureExtractor():
         # convert to decibel-scale melspectrogram: compute dB relative to peak power
         spectrogram = librosa.core.power_to_db(spectrogram, ref=np.max)
         # normalize data
-        spectrogram = (spectrogram - np.min(spectrogram)) / (np.max(spectrogram) - np.min(spectrogram))
+        spectrogram = (spectrogram - (-80)) / (0 - (-80))
         # add dimension for channel
         spectrogram = np.expand_dims(spectrogram, axis=-1)
         # flip frequency axis so low frequencies are at bottom of image

--- a/src/deepdiva/features/feature_extractor.py
+++ b/src/deepdiva/features/feature_extractor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+import os
+import numpy as np
+import pickle
+import librosa
+
+
+class FeatureExtractor():
+
+    def __init__(self,
+                 data_path="./data/train_4params",
+                 saved_scaler=False,
+                 scaler_file="mfcc_scaler.pickle"):
+
+        """
+        Constructor
+        """
+
+        self.data_path = data_path
+        self.saved_scaler = saved_scaler
+        self.scaler_file = scaler_file
+
+
+    def melspectrogram(self, audio=None, n_fft=2048, win_length=None, hop_length=512,
+                       n_mels=128, sample_rate=44100, freq_min=0, freq_max=None):
+        """
+        :param audio: audio time-series, numpy array
+        :param n_fft: number of Fast Fourier Transform components
+        :param win_length: each frame of audio is windowed by window() and
+                           will be of length win_length and then padded with zeros
+        :param hop_length: number of samples between successive frames
+        :param n_mels: number of Mel bands to return
+        :param sample_rate: sampling rate of the incoming signal
+        :param freq_min: lowest frequency (in Hz)
+        :param freq_max: highest frequency (in Hz)
+        :return: Normalized, decibel-scaled mel spectrogram with shape (n_mels, time_slices, channel)
+        """
+        # Assert audio file is specified
+        assert audio is not None, "Please specify the audio file"
+
+        # Assert number of data mel frequency bands is specified
+        assert n_mels is not None, "Please specify the number of Mel bands to return"
+
+        # If win_length is unspecified, defaults to n_fft = win_length
+        if win_length is None:
+            win_length = n_fft
+
+        # If highest frequency (in Hz) is unspecified, defaults to sample rate / 2
+        if freq_max is None:
+            freq_max = sample_rate // 2
+
+        audio = audio.astype("float32")
+
+        spectrogram = librosa.feature.melspectrogram(
+            y=audio,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+            n_mels=n_mels,
+            sr=sample_rate,
+            fmin=freq_min,
+            fmax=freq_max,
+            center=True,
+            power=2.0
+        )
+
+        # convert to decibel-scale melspectrogram: compute dB relative to peak power
+        spectrogram = librosa.core.power_to_db(spectrogram, ref=np.max)
+        # normalize data
+        spectrogram = (spectrogram - np.min(spectrogram)) / (np.max(spectrogram) - np.min(spectrogram))
+        # add dimension for channel
+        spectrogram = np.expand_dims(spectrogram, axis=-1)
+        # flip frequency axis so low frequencies are at bottom of image
+        spectrogram = spectrogram[::-1, :, :]
+
+        return spectrogram
+
+
+    def mfcc(self, audio=None, n_fft=2048, win_length=None, hop_length=1024, n_mfcc=13,
+             sample_rate=44100, freq_min=0, freq_max=None, time_major=True):
+        """
+        :param audio: audio time-series, numpy array
+        :param n_fft: number of Fast Fourier Transform components
+        :param win_length: each frame of audio is windowed by window() and
+                           will be of length win_length and then padded with zeros
+        :param hop_length: number of samples between successive frames
+        :param n_mfcc: number of MFCCs to return
+        :param sample_rate: sampling rate of the incoming signal
+        :param freq_min: lowest frequency (in Hz)
+        :param freq_max: highest frequency (in Hz)
+        :param time_major: change data to shape (time_slices, n_mfcc) for modelling
+        :return: Normalized MFCCs with shape (time_slices, n_mfcc)
+        """
+
+        # Assert audio file is specified
+        assert audio is not None, "Please specify the audio file"
+
+        # Assert number of data mel frequency bands is specified
+        assert n_mfcc is not None, "Please specify the number of MFCCs to return"
+
+        # Assert that the saved scaler object exists if used
+        if self.saved_scaler:
+            assert self.scaler_file is not None, "Please specify scaler file when using previously saved scaler object"
+            assert os.path.exists(os.path.join(self.data_path, self.scaler_file)), "The specified scaler file does not exist"
+
+        # If win_length is unspecified, defaults to n_fft = win_length
+        if win_length is None:
+            win_length = n_fft
+
+        # If highest frequency (in Hz) is unspecified, defaults to sample rate / 2
+        if freq_max is None:
+            freq_max = sample_rate // 2
+
+        audio = audio.astype("float32")
+
+        mfcc = librosa.feature.mfcc(
+            y=audio,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+            n_mfcc=13,
+            sr=sample_rate,
+            fmin=freq_min,
+            fmax=freq_max
+        )
+
+        # Change data to shape (time_slices, n_mfcc) for modelling
+        if time_major:
+            mfcc = np.transpose(mfcc)
+
+        # Normalize data based on saved data_scaler object
+        if self.saved_scaler:
+            mfcc_scaler = self.__load_data_scaler()
+
+            mfcc = (mfcc - mfcc_scaler["mfcc_min"]) / mfcc_scaler["mfcc_range"]
+
+        return mfcc
+
+
+    def __load_data_scaler(self):
+        # Load previously saved data_scaler.pickle file
+        with open(os.path.join(self.data_path, self.scaler_file), 'rb') as handle:
+            data_scaler = pickle.load(handle)
+
+        return data_scaler
+
+
+
+
+
+
+

--- a/src/deepdiva/features/feature_extractor.py
+++ b/src/deepdiva/features/feature_extractor.py
@@ -8,9 +8,9 @@ import librosa
 class FeatureExtractor():
 
     def __init__(self,
-                 data_path="./data/train_4params",
-                 saved_scaler=False,
-                 scaler_file="mfcc_scaler.pickle"):
+                 data_path,
+                 saved_scaler,
+                 scaler_file):
 
         """
         Constructor
@@ -21,8 +21,8 @@ class FeatureExtractor():
         self.scaler_file = scaler_file
 
 
-    def melspectrogram(self, audio=None, n_fft=2048, win_length=None, hop_length=512,
-                       n_mels=128, sample_rate=44100, freq_min=0, freq_max=None):
+    def melspectrogram(self, audio, n_fft, win_length, hop_length,
+                       n_mels, sample_rate, freq_min, freq_max):
         """
         :param audio: audio time-series, numpy array
         :param n_fft: number of Fast Fourier Transform components
@@ -76,8 +76,8 @@ class FeatureExtractor():
         return spectrogram
 
 
-    def mfcc(self, audio=None, n_fft=2048, win_length=None, hop_length=1024, n_mfcc=13,
-             sample_rate=44100, freq_min=0, freq_max=None, time_major=True):
+    def mfcc(self, audio, n_fft, win_length, hop_length, n_mfcc,
+             sample_rate, freq_min, freq_max, time_major):
         """
         :param audio: audio time-series, numpy array
         :param n_fft: number of Fast Fourier Transform components
@@ -118,7 +118,7 @@ class FeatureExtractor():
             n_fft=n_fft,
             win_length=win_length,
             hop_length=hop_length,
-            n_mfcc=13,
+            n_mfcc=n_mfcc,
             sr=sample_rate,
             fmin=freq_min,
             fmax=freq_max

--- a/src/deepdiva/features/get_features.py
+++ b/src/deepdiva/features/get_features.py
@@ -26,7 +26,7 @@ from deepdiva.features.feature_extractor import FeatureExtractor
               show_default=True, help='Length of the FFT window')
 @click.option('--win-length', 'win_length', default=None, required=False, type=int,
               show_default=True, help='Each frame of audio is windowed by window() and will be of length win_length and then padded with zeros. Defaults to win_length = n_fft')
-@click.option('--hop_length', 'hop_length', default=512, required=True, type=int,
+@click.option('--hop_length', 'hop_length', default=512, required=False, type=int,
               show_default=True, help='Number of samples between successive frames')
 @click.option('--n_mels', 'n_mels', default=128, required=False, type=int,
               show_default=True, help='Number of Mel bands to generate')
@@ -34,10 +34,10 @@ from deepdiva.features.feature_extractor import FeatureExtractor
               show_default=True, help='Number of MFCCs to return')
 @click.option('--sample-rate', 'sample_rate', default=44100, required=False, type=int,
               show_default=True, help='Sampling rate of the incoming signal')
-@click.option('--fmin', 'freq_min', default=0, required=False, type=int,
+@click.option('--fmin', 'freq_min', default=50, required=False, type=int,
               show_default=True, help='Lowest frequency (in Hz)')
-@click.option('--fmax', 'freq_max', default=None, required=False, type=int,
-              show_default=True, help='Highest frequency (in Hz), defaults to sample rate // 2')
+@click.option('--fmax', 'freq_max', default=15000, required=False, type=int,
+              show_default=True, help='Highest frequency (in Hz)')
 @click.option('--time-major/--no-time-major', 'time_major', default=True,
               show_default=True, help='Change MFCC to shape (time_slices, n_mfcc) for modelling')
 
@@ -74,7 +74,7 @@ def main(feature, data_path, data_file, file_prefix, saved_scaler, scaler_file, 
 
     if feature == "mfcc":
         mfcc = np.stack([extractor.mfcc(audio=audio[i], n_fft=n_fft, win_length=win_length, hop_length=hop_length,
-                                      n_mfcc=n_mels, sample_rate=sample_rate, freq_min=freq_min, freq_max=freq_max,
+                                      n_mfcc=n_mfcc, sample_rate=sample_rate, freq_min=freq_min, freq_max=freq_max,
                                       time_major=time_major) \
                          for i in range(audio.shape[0])], axis=0)
 

--- a/src/deepdiva/features/get_features.py
+++ b/src/deepdiva/features/get_features.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+import click
+import os
+import pickle
+import numpy as np
+from dotenv import find_dotenv, load_dotenv
+from deepdiva.features.feature_extractor import FeatureExtractor
+
+
+@click.command()
+@click.option('--feature', 'feature', type=click.Choice(['spectrogram', 'mfcc'], case_sensitive=False),
+              required=True, show_default=True, help="Which type of feature to extract")
+@click.option('--data-path', 'data_path', default="./data/dataset", required=False,
+              type=click.Path(exists=True), show_default=True, help='Path to dataset folder')
+@click.option('--data-file', 'data_file', default=None, required=True, type=str,
+              show_default=True, help='Audio file (file.npy) from which to extract features')
+@click.option('--file-prefix', 'file_prefix', default="", required=False, type=str,
+              show_default=True, help="Prefix for saving generated feature files (e.g. 'train_')")
+@click.option('--saved-scaler/--no-saved-scaler', 'saved_scaler', default=False,
+              show_default=True, help='Whether to use a previously saved data scaler object when extracting MFCCs')
+@click.option('--scaler-file', 'scaler_file', default=None,
+              required=False, type=str, show_default=True, help='File name of saved data scaler object')
+@click.option('--scale-axis', 'scale_axis', default=0, required=False, show_default=True,
+              help='Axis or axes to use for calculating scaling parameteres. Defaults to 0, which scales each MFCC and time series component independently.')
+@click.option('--n_fft', 'n_fft', default=2048, required=False, type=int,
+              show_default=True, help='Length of the FFT window')
+@click.option('--win-length', 'win_length', default=None, required=False, type=int,
+              show_default=True, help='Each frame of audio is windowed by window() and will be of length win_length and then padded with zeros. Defaults to win_length = n_fft')
+@click.option('--hop_length', 'hop_length', default=512, required=True, type=int,
+              show_default=True, help='Number of samples between successive frames')
+@click.option('--n_mels', 'n_mels', default=128, required=False, type=int,
+              show_default=True, help='Number of Mel bands to generate')
+@click.option('--n_mfcc', 'n_mfcc', default=13, required=False, type=int,
+              show_default=True, help='Number of MFCCs to return')
+@click.option('--sample-rate', 'sample_rate', default=44100, required=False, type=int,
+              show_default=True, help='Sampling rate of the incoming signal')
+@click.option('--fmin', 'freq_min', default=0, required=False, type=int,
+              show_default=True, help='Lowest frequency (in Hz)')
+@click.option('--fmax', 'freq_max', default=None, required=False, type=int,
+              show_default=True, help='Highest frequency (in Hz), defaults to sample rate // 2')
+@click.option('--time-major/--no-time-major', 'time_major', default=True,
+              show_default=True, help='Change MFCC to shape (time_slices, n_mfcc) for modelling')
+
+
+def click_main(feature, data_path, data_file, file_prefix, saved_scaler, scaler_file, scale_axis,
+               n_fft, win_length, hop_length, n_mels, n_mfcc, sample_rate, freq_min, freq_max, time_major):
+    """
+    Interface for Click CLI.
+    """
+    main(feature=feature, data_path=data_path, data_file=data_file, file_prefix=file_prefix,
+         saved_scaler=saved_scaler, scaler_file=scaler_file, scale_axis=scale_axis, n_fft=n_fft,
+         win_length=win_length, hop_length=hop_length, n_mels=n_mels, n_mfcc=n_mfcc, sample_rate=sample_rate,
+         freq_min=freq_min, freq_max=freq_max, time_major=time_major)
+
+
+def main(feature, data_path, data_file, file_prefix, saved_scaler, scaler_file, scale_axis, n_fft,
+         win_length, hop_length, n_mels, n_mfcc, sample_rate, freq_min, freq_max, time_major):
+    """Runs data processing scripts to make feature set"""
+
+    # Load audio data file
+    audio = np.load(os.path.join(data_path, data_file))
+
+    # Extract features
+    extractor = FeatureExtractor(data_path=data_path, saved_scaler=saved_scaler, scaler_file=scaler_file)
+
+    if feature == "spectrogram":
+        spectrogram = np.stack([extractor.melspectrogram(audio=audio[i], n_fft=n_fft, win_length=win_length,
+                                                        hop_length=hop_length, n_mels=n_mels, sample_rate=sample_rate,
+                                                        freq_min=freq_min, freq_max=freq_max) \
+                                 for i in range(audio.shape[0])], axis=0)
+
+        # Save mel spectrogram feature set
+        np.save(os.path.join(data_path, f"{file_prefix}melspectrogram.npy"), spectrogram)
+
+    if feature == "mfcc":
+        mfcc = np.stack([extractor.mfcc(audio=audio[i], n_fft=n_fft, win_length=win_length, hop_length=hop_length,
+                                      n_mfcc=n_mels, sample_rate=sample_rate, freq_min=freq_min, freq_max=freq_max,
+                                      time_major=time_major) \
+                         for i in range(audio.shape[0])], axis=0)
+
+        if not saved_scaler:
+            # Normalize features
+            mfcc_min = np.min(mfcc, axis=scale_axis)
+            mfcc_range = np.max(mfcc, axis=scale_axis) - np.min(mfcc, axis=scale_axis)
+            mfcc = (mfcc - mfcc_min) / mfcc_range
+
+            # Save scaling dictionary
+            mfcc_scaling = {"mfcc_min": mfcc_min, "mfcc_range": mfcc_range}
+            with open(os.path.join(data_path, f"{file_prefix}mfcc_scaling.pickle"), 'wb') as handle:
+                pickle.dump(mfcc_scaling, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+        # Save MFCC feature set
+        np.save(os.path.join(data_path, f"{file_prefix}mfcc.npy"), mfcc)
+
+
+if __name__ == '__main__':
+
+    # Find .env automatically by walking up directories until it's found, then
+    # load up the .env entries as environment variables
+    load_dotenv(find_dotenv())
+
+    click_main()


### PR DESCRIPTION
I have created a feature extractor class and added a script (get_features.py) that allows for command line interface when running the script. All possible arguments can be set from the command line and most have default values. 

I would like your advice on the following: Currently each decibel-scaled mel spectrogram is normalized based on its own values. The dB-scaling actually scales all values of the mel spectrogram between 0 and -80 (see explanation of that [here](https://librosa.org/doc/main/generated/librosa.power_to_db.html), we compute dB relative to peak power). Therefore, we could also normalize all spectrograms using those ‘theoretically possible’ values (minimum = -80; range = 80), which means all mel spectrograms are normalized according to the same values.

To test the code --> 
In case you haven't done so, first run:
`pip install -e .`
when you are in the root folder of the repository. This will install the deepdiva module and allows you to run the scripts.

To see all the possible options you can pass when running get_features.py, run from you terminal:
`python src/deepdiva/features/get_features.py --help`

An example of extracting normalized decibel-scaled mel spectrogram features and setting some options. Run from your terminal:
`python src/deepdiva/features/get_features.py --data-path "./data/dataset" --data-file "train_audio.npy" --file-prefix "train_" --fmax 20000 --feature "spectrogram"`


An example of extracting mfcc features. For mfcc you have to indicate whether you want to use a previously saved scaler object for normalizing (e.g. when extracting MFCCs for validation and test data). This defaults to False, so it would create and save a data scaler object based on the data. Run from your terminal:
`python src/deepdiva/features/get_features.py --data-path "./data/dataset" --data-file "train_audio.npy" --file-prefix "train_" --fmax 20000 --feature "mfcc" --saved-scaler --scaler-file "train_mfcc_scaling.pickle"`